### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 An local STDIO MCP server that provides tools to search and retrieve Google Gemini API documentation.
 
+<a href="https://glama.ai/mcp/servers/@philschmid/gemini-api-docs-mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@philschmid/gemini-api-docs-mcp/badge" alt="Gemini Docs Server MCP server" />
+</a>
+
 -   **Search Documentation**: Full-text search across all Gemini documentation pages.
 -   **Get Capabilities**: List available documentation pages or retrieve content for a specific page.
 -   **Get Current Model**: Quickly access documentation for current Gemini models.


### PR DESCRIPTION
This PR adds a badge for the [Gemini Docs MCP Server](https://glama.ai/mcp/servers/@philschmid/gemini-api-docs-mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@philschmid/gemini-api-docs-mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@philschmid/gemini-api-docs-mcp/badge" alt="Gemini Docs Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.