### PR TITLE
Sanitize more FTS special characters when querying db with the keywords

### DIFF
--- a/gemini_docs_mcp/config.py
+++ b/gemini_docs_mcp/config.py
@@ -17,8 +17,8 @@ def get_db_path() -> str:
         # Check if we're in a container by checking for /.dockerenv or K_SERVICE (Cloud Run)
         if os.path.exists("/.dockerenv") or os.environ.get("K_SERVICE") or os.environ.get("CONTAINER") == "true":
             db_path = Path("/tmp") / "gemini-api-docs" / "database.db"
-    else:
-        db_path = Path.home() / ".mcp" / "gemini-api-docs" / "database.db"
+        else:
+            db_path = Path.home() / ".mcp" / "gemini-api-docs" / "database.db"
     
     # Ensure directory exists
     db_path.parent.mkdir(parents=True, exist_ok=True)

--- a/gemini_docs_mcp/config.py
+++ b/gemini_docs_mcp/config.py
@@ -17,8 +17,8 @@ def get_db_path() -> str:
         # Check if we're in a container by checking for /.dockerenv or K_SERVICE (Cloud Run)
         if os.path.exists("/.dockerenv") or os.environ.get("K_SERVICE") or os.environ.get("CONTAINER") == "true":
             db_path = Path("/tmp") / "gemini-api-docs" / "database.db"
-        else:
-            db_path = Path.home() / ".mcp" / "gemini-api-docs" / "database.db"
+    else:
+        db_path = Path.home() / ".mcp" / "gemini-api-docs" / "database.db"
     
     # Ensure directory exists
     db_path.parent.mkdir(parents=True, exist_ok=True)

--- a/tests/test_sanitize.py
+++ b/tests/test_sanitize.py
@@ -1,0 +1,15 @@
+import sys
+import os
+
+# Add the project root to sys.path to import gemini_docs_mcp
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from gemini_docs_mcp.server import sanitize_term
+
+def test_sanitize_term():
+    assert sanitize_term("google") == "google"
+    assert sanitize_term("@google/genai") == '"@google/genai"'
+    assert sanitize_term("gemini-2.5-flash") == '"gemini-2.5-flash"'
+
+if __name__ == "__main__":
+    test_sanitize_term()

--- a/tests/test_sanitize.py
+++ b/tests/test_sanitize.py
@@ -1,8 +1,6 @@
 import sys
 import os
 
-# Add the project root to sys.path to import gemini_docs_mcp
-sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 from gemini_docs_mcp.server import sanitize_term
 


### PR DESCRIPTION
This is to make sure MCP tool call won't fail when querying keywords like '@google/genai', 'gemini-3-flash-preview'